### PR TITLE
properly remove empty tag objects

### DIFF
--- a/DropInventory/data/dinv/functions/private/give_next.mcfunction
+++ b/DropInventory/data/dinv/functions/private/give_next.mcfunction
@@ -3,6 +3,9 @@
 # Do not call this function
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/chest.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/chest.mcfunction
@@ -4,6 +4,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/feet.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/feet.mcfunction
@@ -4,6 +4,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/head.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/head.mcfunction
@@ -4,6 +4,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/eight.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/eight.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/five.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/five.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/four.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/four.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/nine.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/nine.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/one.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/one.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/seven.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/seven.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/six.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/six.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/three.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/three.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/hotbar/two.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/hotbar/two.mcfunction
@@ -3,6 +3,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/legs.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/legs.mcfunction
@@ -4,6 +4,9 @@ data modify storage dinv:storage Query append from storage dinv:storage WorkingI
 
 
 data remove storage dinv:storage Query[0].tag.dinv
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query[0] merge value {Slot:0b}
 
 data remove block 0 1 0 Items

--- a/DropInventory/data/dinv/functions/private/update/offhand.mcfunction
+++ b/DropInventory/data/dinv/functions/private/update/offhand.mcfunction
@@ -3,6 +3,9 @@
 
 # Obtains all items with this tag
 data modify storage dinv:storage Query set value []
+data modify storage dinv:temp tag set from storage dinv:storage Query[0].tag
+execute store result score fix.empty_tag dinv run data modify storage dinv:temp tag set value {}
+execute if score fix.empty_tag dinv matches 0 run data remove storage dinv:storage Query[0].tag
 data modify storage dinv:storage Query append from storage dinv:storage WorkingInventory[{tag:{dinv:{Slot:-106b}}}]
 
 # Cleans up and puts first item instance


### PR DESCRIPTION
prevents bug where items that were dropped on death cannot be stacked with other items until the items are dropped and picked up again